### PR TITLE
Add support for ElfCluster VIP allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Cluster API Provider ELF Static IP 通过集成的方式为 [Kubernetes Cluster 
 当 ElfMachine 的网络设备的 networkType 为 *IPV4* 且未设置 ipAddrs 的时候，CAPE 会等待 ipAddrs 被设置才会继续创建虚拟机的流程。
 Cluster API Provider ELF Static IP 的 controller 会 watch 所有的 ElfMachine，使用 ElfMachineTemplate 配置的 IPPool 给 ipAddrs 设置 IP。
 
+当 ElfCluster 未设置 ControlPlaneEndpoint.Host 的时候，CAPE 会等待 Host 被设置才会继续创建集群的流程。Cluster API Provider ELF Static IP 的 controller 会 watch 所有的 ElfCluster，使用 ElfCluster 配置的 IPPool 给 Host 设置 IP。
+
 ### 通过 IPPool 名使用
 
 ```yaml
@@ -26,17 +28,18 @@ metadata:
   labels:
 spec:
   pools:
-    - start: 10.255.160.10
-      end: 10.255.160.20
+    - start: 192.168.0.1
+      end: 192.168.0.128
       prefix: 16
-      gateway: 10.255.0.1
+      gateway: 192.168.0.0
   prefix: 16
-  gateway: 10.255.0.1
+  gateway: 192.168.0.0
 
+# 配置 ElfMachine
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElfMachineTemplate
 metadata:
-  name: elfk8s8-control-plane
+  name: mycluster-control-plane
   namespace: default
   labels:
     cluster.x-k8s.io/ip-pool-name: ip-pool-1
@@ -57,7 +60,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElfMachineTemplate
 metadata:
-  name: elfk8s8-worker
+  name: mycluster-worker
   namespace: default
   labels:
     cluster.x-k8s.io/ip-pool-name: ip-pool-1
@@ -73,6 +76,19 @@ spec:
         - networkType: IPV4
           vlan: dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08
       template: de6efbf8-fdae-4cad-9305-231c67d521a8
+
+# 配置 ElfCluster
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ElfCluster
+metadata:
+  name: mycluster
+  namespace: default
+  labels:
+    cluster.x-k8s.io/ip-pool-name: ip-pool-1
+spec:
+  controlPlaneEndpoint:
+    host: ""
+    port: 6443
 ```
 
 ### 通过 IPPool 标签使用
@@ -88,18 +104,18 @@ metadata:
     cluster.x-k8s.io/network-name: vm-network
 spec:
   pools:
-    - start: 10.255.160.10
-      end: 10.255.160.20
+    - start: 192.168.0.1
+      end: 192.168.0.128
       prefix: 16
-      gateway: 10.255.0.1
+      gateway: 192.168.0.0
   prefix: 16
-  gateway: 10.255.0.1
+  gateway: 192.168.0.0
 
----
+# 配置 ElfMachine
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElfMachineTemplate
 metadata:
-  name: elfk8s8-control-plane
+  name: mycluster-control-plane
   namespace: default
   labels:
     cluster.x-k8s.io/ip-pool-group: ip-pool-group-1
@@ -121,7 +137,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElfMachineTemplate
 metadata:
-  name: elfk8s8-worker
+  name: mycluster-worker
   namespace: default
   labels:
     cluster.x-k8s.io/ip-pool-group: ip-pool-group-1
@@ -138,6 +154,20 @@ spec:
         - networkType: IPV4
           vlan: dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08
       template: de6efbf8-fdae-4cad-9305-231c67d521a8
+
+# 配置 ElfCluster
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ElfCluster
+metadata:
+  name: mycluster
+  namespace: default
+  labels:
+    cluster.x-k8s.io/ip-pool-group: ip-pool-group-1
+    cluster.x-k8s.io/network-name: vm-network
+spec:
+  controlPlaneEndpoint:
+    host: ""
+    port: 6443
 ```
 
 ### 默认 IPPool
@@ -154,12 +184,12 @@ metadata:
     ippool.cluster.x-k8s.io/is-default: "true" # 默认 IPPool 需要指定该标签
 spec:
   pools:
-    - start: 10.255.160.10
-      end: 10.255.160.20
+    - start: 192.168.0.1
+      end: 192.168.0.128
       prefix: 16
-      gateway: 10.255.0.1
+      gateway: 192.168.0.0
   prefix: 16
-  gateway: 10.255.0.1
+  gateway: 192.168.0.0
   namePrefix: ip-pool-default
 ```
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,12 +19,47 @@ rules:
 - apiGroups:
   - cluster.x-k8s.io
   resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
   - machines
   - machines/status
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - elfclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - elfclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - elfclusters/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:

--- a/config/samples/elfcluster_ip_pool_labels.yaml
+++ b/config/samples/elfcluster_ip_pool_labels.yaml
@@ -1,0 +1,30 @@
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: ip-pool-1
+  namespace: default
+  labels:
+    cluster.x-k8s.io/ip-pool-group: YOUR_IP_POOL_GROUP_NAME
+    cluster.x-k8s.io/network-name: YOUR_NETWORK_NAME
+spec:
+  pools:
+    - start: YOUR_INPUT_IP
+      end: YOUR_INPUT_IP
+      prefix: YOUR_MASK
+      gateway: YOUR_GATEWAY
+  prefix: YOUR_MASK
+  gateway: YOUR_GATEWAY
+  namePrefix: YOUR_NAME_PREFIX
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ElfCluster
+metadata:
+  name: mycluster
+  namespace: default
+  labels:
+    cluster.x-k8s.io/ip-pool-group: YOUR_IP_POOL_GROUP_NAME
+    cluster.x-k8s.io/network-name: YOUR_NETWORK_NAME
+spec:
+  controlPlaneEndpoint:
+    host: ""
+    port: 6443

--- a/config/samples/elfcluster_ip_pool_name.yaml
+++ b/config/samples/elfcluster_ip_pool_name.yaml
@@ -1,0 +1,26 @@
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: YOUR_IP_POOL_NAME
+  namespace: default
+spec:
+  pools:
+    - start: YOUR_INPUT_IP
+      end: YOUR_INPUT_IP
+      prefix: YOUR_MASK
+      gateway: YOUR_GATEWAY
+  prefix: YOUR_MASK
+  gateway: YOUR_GATEWAY
+  namePrefix: YOUR_NAME_PREFIX
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ElfCluster
+metadata:
+  name: mycluster
+  namespace: default
+  labels:
+    cluster.x-k8s.io/ip-pool-name: YOUR_IP_POOL_NAME
+spec:
+  controlPlaneEndpoint:
+    host: ""
+    port: 6443

--- a/config/samples/elfmachine_ip_pool_labels.yaml
+++ b/config/samples/elfmachine_ip_pool_labels.yaml
@@ -14,6 +14,7 @@ spec:
       gateway: YOUR_GATEWAY
   prefix: YOUR_MASK
   gateway: YOUR_GATEWAY
+  namePrefix: YOUR_NAME_PREFIX
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElfMachineTemplate

--- a/config/samples/elfmachine_ip_pool_name.yaml
+++ b/config/samples/elfmachine_ip_pool_name.yaml
@@ -11,6 +11,7 @@ spec:
       gateway: YOUR_GATEWAY
   prefix: YOUR_MASK
   gateway: YOUR_GATEWAY
+  namePrefix: YOUR_NAME_PREFIX
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElfMachineTemplate

--- a/controllers/elfcluster_controller.go
+++ b/controllers/elfcluster_controller.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	goctx "context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+	capev1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
+	capecontext "github.com/smartxworks/cluster-api-provider-elf/pkg/context"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/config"
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/context"
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam"
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam/metal3io"
+	ipamutil "github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam/util"
+)
+
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfclusters,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfclusters/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfclusters/finalizers,verbs=update
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+
+const (
+	// ClusterStaticIPFinalizer allows ReconcileElfCluster to clean up static ip
+	// resources associated with ElfCluster before removing it from the
+	// API Server.
+	ClusterStaticIPFinalizer = "elfclusterstaticip.infrastructure.cluster.x-k8s.io"
+)
+
+// AddClusterControllerToManager adds the cluster controller to the provided
+// manager.
+func AddClusterControllerToManager(ctx *capecontext.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	var (
+		clusterControlledType     = &capev1.ElfCluster{}
+		clusterControlledTypeName = reflect.TypeOf(clusterControlledType).Elem().Name()
+		controllerNameShort       = fmt.Sprintf("ipam-%s-controller", strings.ToLower(clusterControlledTypeName))
+	)
+
+	// Build the controller context.
+	controllerContext := &capecontext.ControllerContext{
+		ControllerManagerContext: ctx,
+		Name:                     controllerNameShort,
+		Logger:                   ctx.Logger.WithName(controllerNameShort),
+	}
+
+	reconciler := &ElfClusterReconciler{ControllerContext: controllerContext}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		// Watch the controlled, infrastructure resource.
+		For(clusterControlledType).
+		WithOptions(controller.Options{MaxConcurrentReconciles: ctx.MaxConcurrentReconciles}).
+		Complete(reconciler)
+}
+
+// ElfClusterReconciler reconciles a ElfCluster object.
+type ElfClusterReconciler struct {
+	*capecontext.ControllerContext
+}
+
+// Reconcile ensures the back-end state reflects the Kubernetes resource state intent.
+func (r *ElfClusterReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	// Get the ElfCluster resource for this request.
+	var elfCluster capev1.ElfCluster
+	if err := r.Client.Get(r, req.NamespacedName, &elfCluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.Logger.Info("ElfCluster not found, won't reconcile", "key", req.NamespacedName)
+			return reconcile.Result{}, nil
+		}
+
+		return reconcile.Result{}, err
+	}
+
+	// Fetch the CAPI Cluster.
+	cluster, err := capiutil.GetOwnerCluster(r, r.Client, elfCluster.ObjectMeta)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if cluster == nil {
+		r.Logger.Info("Waiting for Cluster Controller to set OwnerRef on ElfCluster", "namespace", elfCluster.Namespace, "elfCluster", elfCluster.Name)
+		return reconcile.Result{}, nil
+	}
+
+	if annotations.IsPaused(cluster, &elfCluster) {
+		r.Logger.V(4).Info("ElfCluster linked to a cluster that is paused", "namespace", elfCluster.Namespace, "elfCluster", elfCluster.Name)
+		return reconcile.Result{}, nil
+	}
+
+	// Create the patch helper.
+	patchHelper, err := patch.NewHelper(&elfCluster, r.Client)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "failed to init patch helper for %s %s/%s", elfCluster.GroupVersionKind(), elfCluster.Namespace, elfCluster.Name)
+	}
+
+	// Create the cluster context for this request.
+	logger := r.Logger.WithValues("namespace", cluster.Namespace, "elfCluster", elfCluster.Name)
+	clusterContext := &context.ClusterContext{
+		IPAMService: metal3io.NewIpam(r.Client, r.Logger),
+		ClusterContext: &capecontext.ClusterContext{
+			ControllerContext: r.ControllerContext,
+			Cluster:           cluster,
+			ElfCluster:        &elfCluster,
+			Logger:            logger,
+			PatchHelper:       patchHelper,
+		},
+	}
+
+	// Always issue a patch when exiting this function so changes to the
+	// resource are patched back to the API server.
+	defer func() {
+		if err := clusterContext.Patch(); err != nil {
+			if reterr == nil {
+				reterr = err
+			}
+
+			clusterContext.Logger.Error(err, "patch failed", "elfCluster", clusterContext.String())
+		}
+	}()
+
+	// Handle deleted clusters
+	if !elfCluster.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(clusterContext)
+	}
+
+	return r.reconcileControlPlaneEndpoint(clusterContext)
+}
+
+func (r *ElfClusterReconciler) reconcileDelete(ctx *context.ClusterContext) (reconcile.Result, error) {
+	if ctx.ElfCluster.Spec.ControlPlaneEndpoint.Host == "" || !ctrlutil.ContainsFinalizer(ctx.ElfCluster, ClusterStaticIPFinalizer) {
+		ctrlutil.RemoveFinalizer(ctx.ElfCluster, ClusterStaticIPFinalizer)
+		return ctrl.Result{}, nil
+	}
+
+	if ctrlutil.ContainsFinalizer(ctx.ElfCluster, capev1.ClusterFinalizer) {
+		ctx.Logger.V(1).Info("Waiting for ClusterFinalizer to be removed")
+		return ctrl.Result{}, nil
+	}
+
+	ipPool, err := r.getIPPool(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if ipPool == nil {
+		return ctrl.Result{}, nil
+	}
+
+	if err := ctx.IPAMService.ReleaseIP(ctx, ipamutil.GetControlPlaneEndpointClaimName(ctx.ElfCluster.Name), ipPool); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	ctrlutil.RemoveFinalizer(ctx.ElfCluster, ClusterStaticIPFinalizer)
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ElfClusterReconciler) reconcileControlPlaneEndpoint(ctx *context.ClusterContext) (reconcile.Result, error) {
+	if ctx.ElfCluster.Spec.ControlPlaneEndpoint.Host != "" {
+		ctx.Logger.V(2).Info("no need to allocate static IP for control plane endpoint")
+		return ctrl.Result{}, nil
+	}
+
+	ctx.Logger.V(1).Info("Reconciling ElfCluster control plane endpoint")
+
+	ipPool, err := r.getIPPool(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if ipPool == nil {
+		return ctrl.Result{}, nil
+	}
+
+	ipName := ipamutil.GetControlPlaneEndpointClaimName(ctx.ElfCluster.Name)
+	ip, err := ctx.IPAMService.GetIP(ctx, ipName, ipPool)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to get allocated IP address %s", ipName)
+	}
+	if ip == nil {
+		if _, err := ctx.IPAMService.AllocateIP(ctx, ipName, ipPool, ctx.ElfCluster); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to allocate IP address %s", ipName)
+		}
+
+		ctx.Logger.Info(fmt.Sprintf("waiting for IP address %s to be available", ipName))
+
+		return ctrl.Result{RequeueAfter: config.DefaultRequeue}, nil
+	}
+
+	if err := ipamutil.ValidateIP(ip); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "invalid IP address retrieved %s", ipName)
+	}
+
+	// If the ElfCluster doesn't have our finalizer, add it.
+	ctrlutil.AddFinalizer(ctx.ElfCluster, ClusterStaticIPFinalizer)
+	ctx.ElfCluster.Spec.ControlPlaneEndpoint.Host = ip.GetAddress()
+
+	ctx.Logger.Info("Set control plane endpoint successfully", "IPAddress", ip.GetName())
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ElfClusterReconciler) getIPPool(ctx *context.ClusterContext) (ipam.IPPool, error) {
+	ipPool, err := ctx.IPAMService.GetAvailableIPPool(ctx, ctx.ElfCluster.Labels, ctx.Cluster.ObjectMeta)
+	if err != nil {
+		ctx.Logger.Error(err, "failed to get an available IPPool")
+		return nil, err
+	}
+	if ipPool == nil {
+		ctx.Logger.Info("waiting for IPPool to be available")
+		return nil, nil
+	}
+
+	return ipPool, nil
+}

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"bytes"
+	goctx "context"
+	"flag"
+	"fmt"
+	"time"
+
+	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	capev1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/config"
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam"
+	ipamutil "github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam/util"
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/test/fake"
+)
+
+var _ = Describe("ElfClusterReconciler", func() {
+	var (
+		logBuffer       *bytes.Buffer
+		elfCluster      *capev1.ElfCluster
+		cluster         *capiv1.Cluster
+		metal3IPPool    *ipamv1.IPPool
+		metal3IPClaim   *ipamv1.IPClaim
+		metal3IPAddress *ipamv1.IPAddress
+	)
+
+	ctx := goctx.Background()
+
+	BeforeEach(func() {
+		// set log
+		if err := flag.Set("logtostderr", "false"); err != nil {
+			_ = fmt.Errorf("Error setting logtostderr flag")
+		}
+		if err := flag.Set("v", "6"); err != nil {
+			_ = fmt.Errorf("Error setting v flag")
+		}
+		klog.SetOutput(GinkgoWriter)
+		logBuffer = new(bytes.Buffer)
+
+		elfCluster, cluster, _, _, _ = fake.NewClusterAndMachineObjects()
+		metal3IPPool = fake.NewMetal3IPPool()
+	})
+
+	Context("Reconcile an ElfCluster", func() {
+		It("should not reconcile when ElfCluster not found", func() {
+			klog.SetOutput(logBuffer)
+			ctrlContext := newCtrlContexts()
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(err).To(BeNil())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(logBuffer.String()).To(ContainSubstring("ElfCluster not found, won't reconcile"))
+		})
+
+		It("should not error and not requeue the request without cluster", func() {
+			klog.SetOutput(logBuffer)
+			ctrlContext := newCtrlContexts(elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(err).To(BeNil())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(logBuffer.String()).To(ContainSubstring("Waiting for Cluster Controller to set OwnerRef on ElfCluster"))
+		})
+
+		It("should not error and not requeue the request when Cluster is paused", func() {
+			klog.SetOutput(logBuffer)
+			cluster.Spec.Paused = true
+			ctrlContext := newCtrlContexts(elfCluster, cluster)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(err).To(BeNil())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(logBuffer.String()).To(ContainSubstring("ElfCluster linked to a cluster that is paused"))
+		})
+
+		It("should not reconcile when no need to allocate static IP", func() {
+			klog.SetOutput(logBuffer)
+			elfCluster.Spec.ControlPlaneEndpoint.Host = fake.IP()
+			ctrlContext := newCtrlContexts(elfCluster, cluster)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(err).To(BeNil())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(logBuffer.String()).To(ContainSubstring("no need to allocate static IP for control plane endpoint"))
+		})
+
+		It("should not reconcile when no IPPool", func() {
+			klog.SetOutput(logBuffer)
+			ctrlContext := newCtrlContexts(elfCluster, cluster)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(err).To(BeNil())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(logBuffer.String()).To(ContainSubstring("waiting for IPPool to be available"))
+			Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfCluster), elfCluster)).To(Succeed())
+			Expect(ctrlutil.ContainsFinalizer(elfCluster, ClusterStaticIPFinalizer)).To(BeFalse())
+		})
+
+		It("should create IPClaim and wait when no IPClaim", func() {
+			klog.SetOutput(logBuffer)
+			elfCluster.Labels = map[string]string{ipam.ClusterIPPoolNameKey: metal3IPPool.Name}
+			ctrlContext := newCtrlContexts(elfCluster, cluster, metal3IPPool)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(err).To(BeNil())
+			Expect(result.RequeueAfter).To(Equal(config.DefaultRequeue))
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("waiting for IP address %s to be available", ipamutil.GetControlPlaneEndpointClaimName(elfCluster.Name))))
+			var ipClaim ipamv1.IPClaim
+			Expect(ctrlContext.Client.Get(ctrlContext, apitypes.NamespacedName{
+				Namespace: metal3IPPool.Namespace,
+				Name:      ipamutil.GetControlPlaneEndpointClaimName(elfCluster.Name),
+			}, &ipClaim)).To(Succeed())
+			Expect(ipClaim.Spec.Pool.Name).To(Equal(metal3IPPool.Name))
+			Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfCluster), elfCluster)).To(Succeed())
+			Expect(ctrlutil.ContainsFinalizer(elfCluster, ClusterStaticIPFinalizer)).To(BeFalse())
+		})
+
+		It("should wait for IP when IPClaim without IP", func() {
+			klog.SetOutput(logBuffer)
+			metal3IPPool.Labels = map[string]string{
+				ipam.ClusterIPPoolGroupKey: "ip-pool-group",
+				ipam.ClusterNetworkNameKey: "ip-pool-vm-network",
+			}
+			elfCluster.Labels = metal3IPPool.Labels
+			metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetControlPlaneEndpointClaimName(elfCluster.Name))
+			ctrlContext := newCtrlContexts(elfCluster, cluster, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(err).To(BeNil())
+			Expect(result.RequeueAfter).To(Equal(config.DefaultRequeue))
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("IPClaim %s already exists, skipping creation", ipamutil.GetControlPlaneEndpointClaimName(elfCluster.Name))))
+			Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("waiting for IP address %s to be available", ipamutil.GetControlPlaneEndpointClaimName(elfCluster.Name))))
+			Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfCluster), elfCluster)).To(Succeed())
+			Expect(ctrlutil.ContainsFinalizer(elfCluster, ClusterStaticIPFinalizer)).To(BeFalse())
+		})
+
+		It("should set IP when IP ready", func() {
+			klog.SetOutput(logBuffer)
+			metal3IPPool.Namespace = ipam.DefaultIPPoolNamespace
+			metal3IPPool.Labels = map[string]string{ipam.DefaultIPPoolKey: "true"}
+			metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetControlPlaneEndpointClaimName(elfCluster.Name))
+			setMetal3IPForClaim(metal3IPClaim, metal3IPAddress)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(err).To(BeNil())
+			Expect(result).To(BeZero())
+			Expect(logBuffer.String()).To(ContainSubstring("Set control plane endpoint successfully"))
+			Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfCluster), elfCluster)).To(Succeed())
+			Expect(elfCluster.Spec.ControlPlaneEndpoint.Host).To(Equal(string(metal3IPAddress.Spec.Address)))
+			Expect(ctrlutil.ContainsFinalizer(elfCluster, ClusterStaticIPFinalizer)).To(BeTrue())
+		})
+	})
+
+	Context("Delete a ElfCluster", func() {
+		BeforeEach(func() {
+			ctrlutil.AddFinalizer(elfCluster, capev1.ClusterFinalizer)
+			ctrlutil.AddFinalizer(elfCluster, ClusterStaticIPFinalizer)
+			elfCluster.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+		})
+
+		It("should delete normally after ClusterFinalizer was removed", func() {
+			ctrlutil.RemoveFinalizer(elfCluster, capev1.ClusterFinalizer)
+			ctrlContext := newCtrlContexts(elfCluster, cluster)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(result).To(BeZero())
+			Expect(err).To(BeNil())
+			Expect(apierrors.IsNotFound(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfCluster), elfCluster))).To(BeTrue())
+		})
+
+		It("should not reconcile when without ClusterFinalizer", func() {
+			ctrlutil.RemoveFinalizer(elfCluster, ClusterStaticIPFinalizer)
+			elfCluster.Spec.ControlPlaneEndpoint.Host = string(metal3IPAddress.Spec.Address)
+			ctrlContext := newCtrlContexts(elfCluster, cluster)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(result).To(BeZero())
+			Expect(err).To(BeNil())
+			Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfCluster), elfCluster)).To(Succeed())
+			Expect(ctrlutil.ContainsFinalizer(elfCluster, ClusterStaticIPFinalizer)).To(BeFalse())
+		})
+
+		It("should remove ClusterStaticIPFinalizer and delete related IPs", func() {
+			klog.SetOutput(logBuffer)
+			metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetControlPlaneEndpointClaimName(elfCluster.Name))
+			elfCluster.Spec.ControlPlaneEndpoint.Host = string(metal3IPAddress.Spec.Address)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(result).To(BeZero())
+			Expect(err).To(BeNil())
+			Expect(logBuffer.String()).To(ContainSubstring("Waiting for ClusterFinalizer to be removed"))
+			Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfCluster), elfCluster)).To(Succeed())
+			Expect(ctrlutil.ContainsFinalizer(elfCluster, ClusterStaticIPFinalizer)).To(BeTrue())
+		})
+
+		It("should remove ClusterStaticIPFinalizer and delete related IPs", func() {
+			klog.SetOutput(logBuffer)
+			ctrlutil.RemoveFinalizer(elfCluster, capev1.ClusterFinalizer)
+			metal3IPPool.Namespace = ipam.DefaultIPPoolNamespace
+			metal3IPPool.Labels = map[string]string{ipam.DefaultIPPoolKey: "true"}
+			metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetControlPlaneEndpointClaimName(elfCluster.Name))
+			setMetal3IPForClaim(metal3IPClaim, metal3IPAddress)
+			elfCluster.Spec.ControlPlaneEndpoint.Host = string(metal3IPAddress.Spec.Address)
+			ctrlContext := newCtrlContexts(elfCluster, cluster, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+
+			reconciler := &ElfClusterReconciler{ctrlContext}
+			result, err := reconciler.Reconcile(goctx.Background(), ctrl.Request{NamespacedName: capiutil.ObjectKey(elfCluster)})
+			Expect(result).To(BeZero())
+			Expect(err).To(BeNil())
+			Expect(apierrors.IsNotFound(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfCluster), elfCluster))).To(BeTrue())
+		})
+	})
+})

--- a/controllers/elfcluster_controller_test.go
+++ b/controllers/elfcluster_controller_test.go
@@ -155,7 +155,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			Expect(ctrlutil.ContainsFinalizer(elfCluster, ClusterStaticIPFinalizer)).To(BeFalse())
 		})
 
-		It("should wait for IP when IPClaim without IP", func() {
+		It("should wait for IP when IPClaim does not get IP yet", func() {
 			klog.SetOutput(logBuffer)
 			metal3IPPool.Labels = map[string]string{
 				ipam.ClusterIPPoolGroupKey: "ip-pool-group",
@@ -176,7 +176,7 @@ var _ = Describe("ElfClusterReconciler", func() {
 			Expect(ctrlutil.ContainsFinalizer(elfCluster, ClusterStaticIPFinalizer)).To(BeFalse())
 		})
 
-		It("should set IP when IP ready", func() {
+		It("should set IP when IPClaim gets IP", func() {
 			klog.SetOutput(logBuffer)
 			metal3IPPool.Namespace = ipam.DefaultIPPoolNamespace
 			metal3IPPool.Labels = map[string]string{ipam.DefaultIPPoolKey: "true"}

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -200,7 +200,7 @@ func (r *ElfMachineReconciler) reconcileDelete(ctx *context.MachineContext) (rec
 			continue
 		}
 
-		if err := ctx.IPAMService.ReleaseIP(ctx, ipamutil.GetFormattedClaimName(ctx.ElfMachine.Name, i), ipPool); err != nil {
+		if err := ctx.IPAMService.ReleaseIP(ctx, ipamutil.GetDeviceClaimName(ctx.ElfMachine.Name, i), ipPool); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -269,7 +269,7 @@ func (r *ElfMachineReconciler) reconcileIPAddress(ctx *context.MachineContext) (
 }
 
 func (r *ElfMachineReconciler) reconcileDeviceIPAddress(ctx *context.MachineContext, ipPool ipam.IPPool, index int) (reconcile.Result, error) {
-	ipName := ipamutil.GetFormattedClaimName(ctx.ElfMachine.Name, index)
+	ipName := ipamutil.GetDeviceClaimName(ctx.ElfMachine.Name, index)
 	ip, err := ctx.IPAMService.GetIP(ctx, ipName, ipPool)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to get allocated IP address %s", ipName)

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -194,11 +194,11 @@ var _ = Describe("ElfMachineReconciler", func() {
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result.RequeueAfter).To(Equal(config.DefaultRequeue))
 		Expect(err).To(BeNil())
-		Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("waiting for IP address %s to be available", ipamutil.GetFormattedClaimName(elfMachine.Name, 0))))
+		Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("waiting for IP address %s to be available", ipamutil.GetDeviceClaimName(elfMachine.Name, 0))))
 		var ipClaim ipamv1.IPClaim
 		Expect(ctrlContext.Client.Get(ctrlContext, apitypes.NamespacedName{
 			Namespace: metal3IPPool.Namespace,
-			Name:      ipamutil.GetFormattedClaimName(elfMachine.Name, 0),
+			Name:      ipamutil.GetDeviceClaimName(elfMachine.Name, 0),
 		}, &ipClaim)).To(Succeed())
 		Expect(ipClaim.Spec.Pool.Name).To(Equal(metal3IPPool.Name))
 		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
@@ -212,7 +212,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 			ipam.ClusterNetworkNameKey: "ip-pool-vm-network",
 		}
 		elfMachineTemplate.Labels = metal3IPPool.Labels
-		metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetFormattedClaimName(elfMachine.Name, 0))
+		metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetDeviceClaimName(elfMachine.Name, 0))
 		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim)
 		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
 
@@ -220,8 +220,8 @@ var _ = Describe("ElfMachineReconciler", func() {
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result.RequeueAfter).To(Equal(config.DefaultRequeue))
 		Expect(err).To(BeNil())
-		Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("IPClaim %s already exists, skipping creation", ipamutil.GetFormattedClaimName(elfMachine.Name, 0))))
-		Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("waiting for IP address %s to be available", ipamutil.GetFormattedClaimName(elfMachine.Name, 0))))
+		Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("IPClaim %s already exists, skipping creation", ipamutil.GetDeviceClaimName(elfMachine.Name, 0))))
+		Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("waiting for IP address %s to be available", ipamutil.GetDeviceClaimName(elfMachine.Name, 0))))
 		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeTrue())
 	})
@@ -230,7 +230,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		klog.SetOutput(logBuffer)
 		metal3IPPool.Namespace = ipam.DefaultIPPoolNamespace
 		metal3IPPool.Labels = map[string]string{ipam.DefaultIPPoolKey: "true"}
-		metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetFormattedClaimName(elfMachine.Name, 0))
+		metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetDeviceClaimName(elfMachine.Name, 0))
 		setMetal3IPForClaim(metal3IPClaim, metal3IPAddress)
 		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
 		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
@@ -281,7 +281,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		It("should remove MachineStaticIPFinalizer and delete related IPs", func() {
 			metal3IPPool.Namespace = ipam.DefaultIPPoolNamespace
 			metal3IPPool.Labels = map[string]string{ipam.DefaultIPPoolKey: "true"}
-			metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetFormattedClaimName(elfMachine.Name, 0))
+			metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetDeviceClaimName(elfMachine.Name, 0))
 			setMetal3IPForClaim(metal3IPClaim, metal3IPAddress)
 			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
 			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -205,7 +205,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeTrue())
 	})
 
-	It("should wait for IP when IPClaim without IP", func() {
+	It("should wait for IP when IPClaim does not get IP yet", func() {
 		klog.SetOutput(logBuffer)
 		metal3IPPool.Labels = map[string]string{
 			ipam.ClusterIPPoolGroupKey: "ip-pool-group",

--- a/main.go
+++ b/main.go
@@ -130,6 +130,10 @@ func main() {
 
 	// Create a function that adds all of the controllers and webhooks to the manager.
 	addToManager := func(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+		if err := controllers.AddClusterControllerToManager(ctx, mgr); err != nil {
+			return err
+		}
+
 		if err := controllers.AddMachineControllerToManager(ctx, mgr); err != nil {
 			return err
 		}

--- a/pkg/context/cluster_context.go
+++ b/pkg/context/cluster_context.go
@@ -14,12 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package context
 
-import "time"
+import (
+	capecontext "github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 
-var (
-	// DefaultRequeue is the default time for how long to wait when
-	// requeueing a IPAM operation.
-	DefaultRequeue = 10 * time.Second
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam"
 )
+
+// ClusterContext is a Go context used with a ElfCluster.
+type ClusterContext struct {
+	*capecontext.ClusterContext
+	IPAMService ipam.IPAddressManager
+}

--- a/pkg/ipam/util/util.go
+++ b/pkg/ipam/util/util.go
@@ -84,6 +84,10 @@ func GetObjRef(obj runtime.Object) corev1.ObjectReference {
 	}
 }
 
-func GetFormattedClaimName(ownerName string, deviceCount int) string {
+func GetControlPlaneEndpointClaimName(ownerName string) string {
+	return fmt.Sprintf("%s-controlplane-endpoint", ownerName)
+}
+
+func GetDeviceClaimName(ownerName string, deviceCount int) string {
 	return fmt.Sprintf("%s-%d", ownerName, deviceCount)
 }

--- a/test/fake/capi.go
+++ b/test/fake/capi.go
@@ -44,6 +44,12 @@ func NewClusterAndMachineObjects() (*capev1.ElfCluster, *capiv1.Cluster, *capev1
 	return elfCluster, cluster, elfMachine, machine, template
 }
 
+func InitClusterOwnerReferences(
+	ctrlContext *context.ControllerContext,
+	elfCluster *capev1.ElfCluster, cluster *capiv1.Cluster) {
+	capefake.InitClusterOwnerReferences(ctrlContext, elfCluster, cluster)
+}
+
 func InitOwnerReferences(
 	ctrlContext *context.ControllerContext,
 	elfCluster *capev1.ElfCluster, cluster *capiv1.Cluster,


### PR DESCRIPTION
### 自动分配 VIP 

### 测试

```yaml
apiVersion: ipam.metal3.io/v1alpha1
kind: IPPool
metadata:
  name: ip-pool-default
  namespace: cape-system
  labels:
    ippool.cluster.x-k8s.io/is-default: "true"
spec:
  pools:
    - start: 10.255.160.10
      end: 10.255.160.20
      prefix: 16
      gateway: 10.255.0.1
  prefix: 16
  gateway: 10.255.0.1
  namePrefix: "ip-pool-default"
  dnsServers: []
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s8
  name: elfk8s8
  namespace: default
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 100.96.0.0/11
  controlPlaneRef:
    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    kind: KubeadmControlPlane
    name: elfk8s8-control-plane
  infrastructureRef:
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: ElfCluster
    name: elfk8s8
```

```yaml
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfCluster
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"infrastructure.cluster.x-k8s.io/v1beta1","kind":"ElfCluster","metadata":{"annotations":{},"name":"elfk8s8","namespace":"default"},"spec":{"cluster":"dd1f408f-7715-48c1-a817-13c3568f1d93","controlPlaneEndpoint":{"host":"","port":6443},"tower":{"authMode":"LOCAL","password":"K5yt3hcjtUE4Teqe","server":"tower.caas.smtx.io","username":"system-service"}}}
  creationTimestamp: "2022-08-31T11:04:19Z"
  finalizers:
  - elfcluster.infrastructure.cluster.x-k8s.io
  - elfclusterstaticip.infrastructure.cluster.x-k8s.io
  generation: 2
  labels:
    cluster.x-k8s.io/cluster-name: elfk8s8
  name: elfk8s8
  namespace: default
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: Cluster
    name: elfk8s8
    uid: d500d2d8-5cbb-455c-9eb4-13a2d3bb918d
  resourceVersion: "105010"
  uid: 0d9edec9-b0f2-4541-a251-90a9d0a8ce59
spec:
  cluster: dd1f408f-7715-48c1-a817-13c3568f1d93
  controlPlaneEndpoint:
    host: 10.255.160.10
    port: 6443
  tower:
    authMode: LOCAL
    password: K5yt3hcjtUE4Teqe
    server: tower.caas.smtx.io
    username: system-service
status:
  ready: true
```