### PR TITLE
Use IPPool DNS servers for ElfMachine

### DIFF
--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -234,6 +234,7 @@ var _ = Describe("ElfMachineReconciler", func() {
 		Expect(logBuffer.String()).To(ContainSubstring("Set IP address successfully"))
 		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(elfMachine.Spec.Network.Devices[0].IPAddrs).To(Equal([]string{string(metal3IPAddress.Spec.Address)}))
+		// DNS server is unique and DNS server priority of ElfMachine is higher than IPPool.
 		Expect(elfMachine.Spec.Network.Nameservers).To(Equal([]string{"3.3.3.3", "2.2.2.2", "1.1.1.1"}))
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeTrue())
 	})

--- a/pkg/ipam/metal3io/ip.go
+++ b/pkg/ipam/metal3io/ip.go
@@ -70,7 +70,7 @@ func (m *Metal3IP) GetAddress() string {
 
 func (m *Metal3IP) GetDNSServers() []string {
 	dnsServers := make([]string, 0, len(m.Spec.DNSServers))
-	for i := 0; i < len(dnsServers); i++ {
+	for i := 0; i < len(m.Spec.DNSServers); i++ {
 		dnsServers = append(dnsServers, string(m.Spec.DNSServers[i]))
 	}
 

--- a/pkg/ipam/metal3io/ippool.go
+++ b/pkg/ipam/metal3io/ippool.go
@@ -76,7 +76,7 @@ func (m *Metal3IPPool) GetGateway() string {
 func (m *Metal3IPPool) GetDNSServers() []string {
 	dnsServers := make([]string, 0, len(m.IPPool.Spec.DNSServers))
 	for i := 0; i < len(m.IPPool.Spec.DNSServers); i++ {
-		dnsServers[i] = string(m.IPPool.Spec.DNSServers[i])
+		dnsServers = append(dnsServers, string(m.IPPool.Spec.DNSServers[i]))
 	}
 
 	return dnsServers

--- a/pkg/ipam/util/util.go
+++ b/pkg/ipam/util/util.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (
@@ -10,6 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam"
+)
+
+// Elf virtual machine support three DNS servers.
+const (
+	DNSServerLimit = 3
 )
 
 func HasStaticIPDevice(devices []capev1.NetworkDeviceSpec) bool {
@@ -58,6 +79,26 @@ func ValidateIP(ip ipam.IPAddress) error {
 	}
 
 	return nil
+}
+
+func LimitDNSServers(sourceDNSServers []string) []string {
+	dnsServers := []string{}
+	set := make(map[string]struct{}, len(sourceDNSServers))
+	for i := 0; i < len(sourceDNSServers); i++ {
+		if _, ok := set[sourceDNSServers[i]]; ok {
+			continue
+		}
+
+		dnsServers = append(dnsServers, sourceDNSServers[i])
+		set[sourceDNSServers[i]] = struct{}{}
+	}
+
+	limit := DNSServerLimit
+	if limit > len(dnsServers) {
+		limit = len(dnsServers)
+	}
+
+	return dnsServers[:limit]
 }
 
 func IgnoreNotFound(err error) error {

--- a/pkg/ipam/util/util_test.go
+++ b/pkg/ipam/util/util_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestLimitDNSServers(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	testCases := []struct {
+		name             string
+		sourceDNSServers []string
+		dnsServers       []string
+	}{
+		{"should return empty server", []string{}, []string{}},
+		{"should return one server", []string{"1.1.1.1"}, []string{"1.1.1.1"}},
+		{"should filter duplicate servers", []string{"1.1.1.1", "1.1.1.1"}, []string{"1.1.1.1"}},
+		{"should limit servers", []string{"1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4"}, []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dnsServers := LimitDNSServers(tc.sourceDNSServers)
+			g.Expect(dnsServers).To(gomega.Equal(tc.dnsServers))
+		})
+	}
+}


### PR DESCRIPTION
使用 IPPool 配置的 DNS

优先级：ElfMachineTemplate > IPPool

```yaml
apiVersion: ipam.metal3.io/v1alpha1
kind: IPPool
metadata:
  name: ip-pool-default
  namespace: cape-system
  labels:
    ippool.cluster.x-k8s.io/is-default: "true"
spec:
  pools:
    - start: 10.255.160.10
      end: 10.255.160.20
      prefix: 16
      gateway: 10.255.0.1
      dnsServers: [114.114.115.115]
  prefix: 16
  gateway: 10.255.0.1
  namePrefix: "ip-pool-default"
  dnsServers: [114.114.114.114, 114.114.116.116]

---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ElfMachineTemplate
metadata:
  name: elfk8s8-control-plane
  namespace: default
spec:
  template:
    spec:
      cloneMode: FastClone
      ha: true
      numCPUS: 4
      memoryMiB: 6144
      diskGiB: 20
      network:
        nameservers:
        - 8.8.8.8
        devices:
        - networkType: IPV4
          vlan: dd1f408f-7715-48c1-a817-13c3568f1d93_4cd00407-63ca-440b-80b7-ceacfccb8d08
      template: de6efbf8-fdae-4cad-9305-231c67d521a8
```