### PR TITLE
Add CAPI metadata.yaml and add namespace resource in release manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ manifests: $(MANIFEST_DIR) $(BUILD_DIR) kustomize
 	sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' $(BUILD_DIR)/config/default/manager_pull_policy.yaml
 	sed -i'' -e 's@image: .*@image: '"$(IMAGE)"'@' $(BUILD_DIR)/config/default/manager_image_patch.yaml
 	$(KUSTOMIZE) build $(BUILD_DIR)/config/default > $(MANIFEST_DIR)/static-ip-components.yaml
+	cp metadata.yaml $(MANIFEST_DIR)/metadata.yaml
 
 ## --------------------------------------
 ## Cleanup / Verification

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,6 +12,9 @@ namePrefix: cape-ip-
 #commonLabels:
 #  someName: someValue
 
+resources:
+- namespace.yaml
+
 bases:
 - ../crd
 - ../rbac

--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,11 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 0
+    minor: 1
+    contract: v1beta1


### PR DESCRIPTION
Add CAPI metadata.yaml and add namespace resource in release manifests
- metadata.yaml is needed by CAPI clusterctl.
- namespace cape-system is needed for deploying cape-static-ip.

Refer to CAPI files:
- https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.2.2
- https://github.com/kubernetes-sigs/cluster-api/blob/v1.2.2/Makefile#L748
- https://github.com/kubernetes-sigs/cluster-api/blob/v1.2.2/config/default/kustomization.yaml#L8