### PR TITLE
Upgrade CAPE to v0.4.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.20.2
 	github.com/pkg/errors v0.9.1
-	github.com/smartxworks/cluster-api-provider-elf v0.4.6
+	github.com/smartxworks/cluster-api-provider-elf v0.4.8
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 	k8s.io/apiextensions-apiserver v0.24.2
 	k8s.io/apiserver v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -543,8 +543,8 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartxworks/cloudtower-go-sdk/v2 v2.3.0 h1:f4cYFciXSMQM+/BnHKf2+4a0mJ4Ue4jCLGSH8qAm5xE=
 github.com/smartxworks/cloudtower-go-sdk/v2 v2.3.0/go.mod h1:F2v9VWvT2sPZWejkHs7NuwwnCeB84uUSJstNERUs9y4=
-github.com/smartxworks/cluster-api-provider-elf v0.4.6 h1:8iUXanxXrcxOPf5wZ5dk/NrCRZ91qyr0WVHiTZYQ6ZA=
-github.com/smartxworks/cluster-api-provider-elf v0.4.6/go.mod h1:vmct0P0P18DzSCfzyNe7S0s44uYxb7gJH4t7XzgzBmE=
+github.com/smartxworks/cluster-api-provider-elf v0.4.8 h1:4n+nZfgwOIQiScLmg+7hz3/DOs//F34/S8iOqtiWvbE=
+github.com/smartxworks/cluster-api-provider-elf v0.4.8/go.mod h1:vmct0P0P18DzSCfzyNe7S0s44uYxb7gJH4t7XzgzBmE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
Changelog:
- https://github.com/smartxworks/cluster-api-provider-elf/releases/tag/v0.4.8