### PR TITLE
Upgrade CAPI to v1.4.1 and CAPE to v1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,15 +13,15 @@ require (
 require (
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.9.2
-	github.com/onsi/gomega v1.27.4
+	github.com/onsi/gomega v1.27.6
 	github.com/pkg/errors v0.9.1
-	github.com/smartxworks/cluster-api-provider-elf v1.2.0
+	github.com/smartxworks/cluster-api-provider-elf v1.2.1
 	golang.org/x/mod v0.9.0
 	k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apiserver v0.26.1
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
-	sigs.k8s.io/cluster-api v1.4.0
+	sigs.k8s.io/cluster-api v1.4.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/onsi/gomega v1.22.1/go.mod h1:x6n7VNe4hw0vkyYUM4mjIXx3JbLiPaBPNgB7PRQ
 github.com/onsi/gomega v1.24.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
 github.com/onsi/gomega v1.24.2/go.mod h1:gs3J10IS7Z7r7eXRoNJIrNqU4ToQukCJhFtKrWgHWnk=
-github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
-github.com/onsi/gomega v1.27.4/go.mod h1:riYq/GJKh8hhoM01HN6Vmuy93AarCXCBGpvFDK3q3fQ=
+github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
+github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openlyinc/pointy v1.2.0/go.mod h1:JodZOTJoBNaAQHeU0F/SwA4PL0lg4pKF7fYFpX291P0=
@@ -482,8 +482,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartxworks/cloudtower-go-sdk/v2 v2.5.0 h1:tTTV02rUyD6xKF5KgT9tqU3Z1rQfUTuP5iHwTlKVrJ8=
 github.com/smartxworks/cloudtower-go-sdk/v2 v2.5.0/go.mod h1:jYFy73tdddNDbrlNElPyL193WXfvT3G6NK1ExTB3TbA=
-github.com/smartxworks/cluster-api-provider-elf v1.2.0 h1:GEeW4dc36Dsl2jgJpJqdpHFlpGSfs3qoUh9o4K+67Wc=
-github.com/smartxworks/cluster-api-provider-elf v1.2.0/go.mod h1:ofbp2kJHEndeDT2vtgSb7GKt2DEZSC86yLR6sNoepgQ=
+github.com/smartxworks/cluster-api-provider-elf v1.2.1 h1:XdsWxQsM3Z332Xcy+bWv6KFVWF5L8q+fZ071a7w1XCc=
+github.com/smartxworks/cluster-api-provider-elf v1.2.1/go.mod h1:wkc72mlkM8iejKwcmb0w4oWAtTEPVdSFTpH30XSsucY=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -989,8 +989,8 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.4.0 h1:qkFt+yie4kDJQY4qD67rJR/S2dQ1IBZr/B2moYeVzWI=
-sigs.k8s.io/cluster-api v1.4.0/go.mod h1:6w9nUYSE1Mc0HkyjxyQoaDu8L9YmlpFFFn9n9Zvr9U4=
+sigs.k8s.io/cluster-api v1.4.1 h1:GtA7OJGhLvgJMgEIxKIoGLxXezM3THI/Yi10QpQ0EN4=
+sigs.k8s.io/cluster-api v1.4.1/go.mod h1:IIebZTsqyXU8CHbINV2zuMh0/wykqdr+vEXxQNeteEU=
 sigs.k8s.io/controller-runtime v0.14.6 h1:oxstGVvXGNnMvY7TAESYk+lzr6S3V5VFxQ6d92KcwQA=
 sigs.k8s.io/controller-runtime v0.14.6/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=


### PR DESCRIPTION
### CAPI to [v1.4.1](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.4.1) and CAPE to [v1.2.1](https://github.com/smartxworks/cluster-api-provider-elf/releases/tag/v1.2.1)
