### PR TITLE
SKS-1243: Save MachineStaticIPFinalizer first and then allocate IP

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -242,11 +242,14 @@ func (r *ElfMachineReconciler) reconcileIPAddress(ctx *context.MachineContext) (
 
 	ctx.Logger.Info("Reconcile IP address")
 
-	// If the ElfMachine doesn't have our finalizer, add it.
 	// Save MachineStaticIPFinalizer first and then allocate IP.
 	// If the IP has been allocated but the MachineStaticIPFinalizer has not been saved,
 	// deleting the Machine at this time may not release the IP.
+	//
+	// If the ElfMachine doesn't have MachineStaticIPFinalizer, add it.
 	if !ctrlutil.ContainsFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer) {
+		// Set MachineStaticIPFinalizer and return to save it first.
+		// Then later reconciliation can allocate IP.
 		ctrlutil.AddFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer)
 
 		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -173,11 +173,16 @@ func (r *ElfMachineReconciler) Reconcile(ctx goctx.Context, req ctrl.Request) (_
 
 func (r *ElfMachineReconciler) reconcileDelete(ctx *context.MachineContext) (reconcile.Result, error) {
 	if !ipamutil.HasStaticIPDevice(ctx.ElfMachine.Spec.Network.Devices) {
-		ctrlutil.RemoveFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer)
+		if ctrlutil.ContainsFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer) {
+			ctx.Logger.V(1).Info("No static IP network device found, but MachineStaticIPFinalizer is set and remove it")
+
+			ctrlutil.RemoveFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer)
+		}
+
 		return ctrl.Result{}, nil
 	}
 
-	ctx.Logger.V(1).Info("Reconciling ElfMachine IP delete")
+	ctx.Logger.V(1).Info("Reconciling ElfMachine IP delete", "finalizers", ctx.ElfMachine.Finalizers)
 
 	if ctrlutil.ContainsFinalizer(ctx.ElfMachine, capev1.MachineFinalizer) {
 		ctx.Logger.V(1).Info("Waiting for MachineFinalizer to be removed")
@@ -190,6 +195,8 @@ func (r *ElfMachineReconciler) reconcileDelete(ctx *context.MachineContext) (rec
 	}
 	if ipPool == nil {
 		ctrlutil.RemoveFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer)
+
+		r.Logger.V(1).Info("IPPool is not found, remove MachineStaticIPFinalizer")
 
 		return ctrl.Result{}, nil
 	}
@@ -210,6 +217,7 @@ func (r *ElfMachineReconciler) reconcileDelete(ctx *context.MachineContext) (rec
 	}
 
 	ctrlutil.RemoveFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer)
+	r.Logger.V(1).Info("The IPs used by Machine has been released, remove MachineStaticIPFinalizer")
 
 	return reconcile.Result{}, nil
 }
@@ -235,7 +243,14 @@ func (r *ElfMachineReconciler) reconcileIPAddress(ctx *context.MachineContext) (
 	ctx.Logger.Info("Reconcile IP address")
 
 	// If the ElfMachine doesn't have our finalizer, add it.
-	ctrlutil.AddFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer)
+	// Save MachineStaticIPFinalizer first and then allocate IP.
+	// If the IP has been allocated but the MachineStaticIPFinalizer has not been saved,
+	// deleting the Machine at this time may not release the IP.
+	if !ctrlutil.ContainsFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer) {
+		ctrlutil.AddFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer)
+
+		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
+	}
 
 	ipPool, err := r.getIPPool(ctx)
 	if err != nil {
@@ -322,6 +337,7 @@ func (r *ElfMachineReconciler) getIPPool(ctx *context.MachineContext) (ipam.IPPo
 		return nil, err
 	}
 	if ipPool == nil {
+		ctx.Logger.Info("IPPool is not found", "ipPoolNamespace", poolMatchLabels[ipam.ClusterIPPoolNamespaceKey], "ipPoolName", poolMatchLabels[ipam.ClusterIPPoolNameKey], "ipPoolGroupKey", poolMatchLabels[ipam.ClusterIPPoolGroupKey])
 		return nil, nil
 	}
 

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -246,10 +246,9 @@ func (r *ElfMachineReconciler) reconcileIPAddress(ctx *context.MachineContext) (
 	// If the IP has been allocated but the MachineStaticIPFinalizer has not been saved,
 	// deleting the Machine at this time may not release the IP.
 	//
-	// If the ElfMachine doesn't have MachineStaticIPFinalizer, add it.
+	// If the ElfMachine doesn't have MachineStaticIPFinalizer, add it and return with requeue.
+	// In next reconcile, the static IP will be allocated.
 	if !ctrlutil.ContainsFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer) {
-		// Set MachineStaticIPFinalizer and return to save it first.
-		// Then later reconciliation can allocate IP.
 		ctrlutil.AddFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer)
 
 		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil


### PR DESCRIPTION
### [SKS-1243](http://jira.smartx.com/browse/SKS-1243) 
删除集群的时候，偶尔出现 IP 没有释放。

如图所示，最后两行日志可以看出，当 CAPE 移除了 MachineFinalizer 之后，ElfMachine 就直接 404 了，所以没有执行释放 IP 的逻辑。
<img width="1284" alt="image" src="https://user-images.githubusercontent.com/19967151/233988911-249743e0-ab54-47c5-ae6a-2d251bf18ab5.png">

可能存在的原因：
1. Devices 被修改了，被判断为不需要释放 IP 。
```go
func (r *ElfMachineReconciler) reconcileDelete(ctx *context.MachineContext) (reconcile.Result, error) {
	if !ipamutil.HasStaticIPDevice(ctx.ElfMachine.Spec.Network.Devices) {
		ctrlutil.RemoveFinalizer(ctx.ElfMachine, MachineStaticIPFinalizer)
		return ctrl.Result{}, nil
	}
}
```

2. MachineStaticIPFinalizer 被移除了，所以当 MachineFinalizer 被移除之后，ElfMachine 马上被删除了。



目前不能完全确定具体原因，针对上述分析，在释放 IP 的逻辑增加了更多的日志信息。

并在分配 IP 之前，先设置并保存 MachineStaticIPFinalizer。这样可以避免在分配了 IP 但 MachineStaticIPFinalizer 没有保存的时候删除 Machine，这个时候可能会导致因为没有 MachineStaticIPFinalizer 而不会走释放 IP 的逻辑。


### 测试
使用 IP Pool 创建多次集群，分别在随意时间删除集群，IP 均被释放。