### PR TITLE
Bump CAPE to v1.2.8 and IPAM to v1.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/smartxworks/cluster-api-provider-elf-static-ip
 go 1.19
 
 require (
-	github.com/metal3-io/ip-address-manager/api v0.0.0
+	github.com/metal3-io/ip-address-manager/api v1.4.1
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
 	github.com/pkg/errors v0.9.1
-	github.com/smartxworks/cluster-api-provider-elf v1.2.5
+	github.com/smartxworks/cluster-api-provider-elf v1.2.8
 	golang.org/x/mod v0.10.0
 	k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apiserver v0.26.1
@@ -101,5 +101,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/metal3-io/ip-address-manager/api => github.com/metal3-io/ip-address-manager/api v0.0.0-20221208094636-8892d31b812f

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2 h1:hAHbPm5IJGijwng3PWk09JkG9WeqChjprR5s9bBZ+OM=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/metal3-io/ip-address-manager/api v0.0.0-20221208094636-8892d31b812f h1:aF5iHD1Q3oXJwQ8TAKUTf51qJxHMIu49qu2KR/eUCuA=
-github.com/metal3-io/ip-address-manager/api v0.0.0-20221208094636-8892d31b812f/go.mod h1:zOu4JUsFXu5JBVoOFYV/FNDU3v3az7epe2KG7GJp/Dk=
+github.com/metal3-io/ip-address-manager/api v1.4.1 h1:pK+sECCkn3smraMgSKQYX/6BhWQYdzxsVnsoufeVJlk=
+github.com/metal3-io/ip-address-manager/api v1.4.1/go.mod h1:zOnrGpiGDp5QOSBN+ZggSZl4hE7MYqgBfQfCuSN/5i0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -491,8 +491,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.0-sks1.1-rc.2 h1:dg91utWrMm2M99uSPYz3U1N7B4sReZyY8g67BHej28I=
 github.com/smartxworks/cloudtower-go-sdk/v2 v2.0.0-sks1.1-rc.2/go.mod h1:a22xOjZMHOeeOAFWOnlOQl26bpumS+thkl2UAdfKmAc=
-github.com/smartxworks/cluster-api-provider-elf v1.2.5 h1:Xp9Ub0PqfoputsJnYxDb1i/WOi5j4AQpWs4WEQiCLN4=
-github.com/smartxworks/cluster-api-provider-elf v1.2.5/go.mod h1:2Mi4iG3qroCzQ9Amfnk4vPXQbvoMR9tDvsZjgYCw3Dg=
+github.com/smartxworks/cluster-api-provider-elf v1.2.8 h1:t92rdHr7Pjf+YihJ8wrhgJnmOzhbF+blkrMvjSXIdp8=
+github.com/smartxworks/cluster-api-provider-elf v1.2.8/go.mod h1:KXyUdBNaoxDNV2bEU/EQvNbl0zQnaiYU1bx83VSQcx8=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION

CAPE https://github.com/smartxworks/cluster-api-provider-elf/releases/tag/v1.2.8
* SKS-1474: Get VM NIC IP from K8s node to speed up VM reconcile  in https://github.com/smartxworks/cluster-api-provider-elf/pull/124
* SKS-1479: Add ElfMachineMutation webhhok to set cape version to ElfMachine  in https://github.com/smartxworks/cluster-api-provider-elf/pull/125

IPAM https://github.com/metal3-io/ip-address-manager/releases/tag/v1.4.1