### PR TITLE
SKS-2097: Ensure CAPE-IP Deployment can work when a node in the cluster is disconnected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN go mod download
 COPY ./ ./
 
 # Build
+ARG ARCH
 ARG ldflags
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -11,13 +11,25 @@ spec:
     matchLabels:
       control-plane: controller-manager
       cluster.x-k8s.io/provider: infrastructure-cape-static-ip
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
         control-plane: controller-manager
         cluster.x-k8s.io/provider: infrastructure-cape-static-ip
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    cluster.x-k8s.io/provider: infrastructure-cape-static-ip
+                    control-plane: controller-manager
+                topologyKey: kubernetes.io/hostname
+                namespaces:
+                  - cape-system
+              weight: 1
       containers:
       - args:
         - --leader-elect


### PR DESCRIPTION
### Issue
[[SKS-2097] 集群有一个节点失联时应保证已有Deployment能正常工作 - Jira](http://jira.smartx.com/browse/SKS-2097)
