### PR TITLE
SKS-1825: Remove the verification that IP must have a gateway

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -326,7 +326,9 @@ func (r *ElfMachineReconciler) reconcileDeviceIPAddress(ctx *context.MachineCont
 	device := &ctx.ElfMachine.Spec.Network.Devices[index]
 	device.IPAddrs = []string{ip.GetAddress()}
 	device.Netmask = ip.GetMask()
-	device.Routes = []capev1.NetworkDeviceRouteSpec{{Gateway: ip.GetGateway()}}
+	if ip.GetGateway() != "" {
+		device.Routes = []capev1.NetworkDeviceRouteSpec{{Gateway: ip.GetGateway()}}
+	}
 	if len(ip.GetDNSServers()) > 0 {
 		ctx.ElfMachine.Spec.Network.Nameservers = append(ctx.ElfMachine.Spec.Network.Nameservers, ip.GetDNSServers()...)
 	}

--- a/pkg/ipam/util/util.go
+++ b/pkg/ipam/util/util.go
@@ -74,10 +74,6 @@ func ValidateIP(ip ipam.IPAddress) error {
 		return fmt.Errorf("invalid 'mask' in IPAddress")
 	}
 
-	if ip.GetGateway() == "" {
-		return fmt.Errorf("invalid 'gateway' in IPAddress")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Issue

ZBS CSI 的 IP Pool 可以不设置 gateway。

当前 IP Pool 没有校验是否设置了 gateway，但在分配 IP 后会校验是否有 gateway。

## Change

移除分配 IP 后必须有 gateway 的校验。

## Test
 
1. 配置一个没有网关的 IP Pool
2. 使用上述 IP Pool 分配给虚拟机，虚拟机被成功创建