### PR TITLE
[WIP]SKS-1825: Use the default IPPool as the global IPPool

### DIFF
--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -340,12 +340,12 @@ func (r *ElfMachineReconciler) reconcileDeviceIPAddress(ctx *context.MachineCont
 //
 // getIPPool selects IPPool according to the following priorities:
 // (1) Without ip-pool-name
-//    1. select IPPool with `is-default`` label from elfMachine.Namespace
-//    2. select IPPool with `is-default` label from default namespace
+//  1. select IPPool with `is-default“ label from elfMachine.Namespace
+//  2. select IPPool with `is-default` label from default namespace
+//
 // (2) With ip-pool-name(from AddressesFromPools or ElfMachineTemplate)
-//    1. select IPPool using the specified ip-pool-name and ip-pool-namespace
-//    2. select the IPPool named ip-pool-name in the default namespace
-
+//  1. select IPPool using the specified ip-pool-name and ip-pool-namespace
+//  2. select the IPPool named ip-pool-name in the default namespace
 func (r *ElfMachineReconciler) getIPPool(ctx *context.MachineContext, device capev1.NetworkDeviceSpec) (ipam.IPPool, error) {
 	poolMatchLabels := make(map[string]string)
 	// Prefer IPPool of device. Only Metal3 IPPool is supported now.

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -336,6 +336,16 @@ func (r *ElfMachineReconciler) reconcileDeviceIPAddress(ctx *context.MachineCont
 	return ctrl.Result{}, nil
 }
 
+// getIPPool returns the specified IPPool.
+//
+// getIPPool selects IPPool according to the following priorities:
+// (1) Without ip-pool-name
+//    1. select IPPool with `is-default`` label from elfMachine.Namespace
+//    2. select IPPool with `is-default` label from default namespace
+// (2) With ip-pool-name(from AddressesFromPools or ElfMachineTemplate)
+//    1. select IPPool using the specified ip-pool-name and ip-pool-namespace
+//    2. select the IPPool named ip-pool-name in the default namespace
+
 func (r *ElfMachineReconciler) getIPPool(ctx *context.MachineContext, device capev1.NetworkDeviceSpec) (ipam.IPPool, error) {
 	poolMatchLabels := make(map[string]string)
 	// Prefer IPPool of device. Only Metal3 IPPool is supported now.

--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -226,9 +226,11 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 	It("should wait for IP when IPClaim without IP", func() {
 		ctrlutil.AddFinalizer(elfMachine, MachineStaticIPFinalizer)
+		metal3IPPool.Namespace = ipam.DefaultIPPoolNamespace
 		metal3IPPool.Labels = map[string]string{
 			ipam.ClusterIPPoolGroupKey: "ip-pool-group",
 			ipam.ClusterNetworkNameKey: "ip-pool-vm-network",
+			ipam.DefaultIPPoolKey:      "true",
 		}
 		elfMachineTemplate.Labels = metal3IPPool.Labels
 		metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetFormattedClaimName(elfMachine.Namespace, elfMachine.Name, 0))

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,12 +25,16 @@ import (
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	capev1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	capecontext "github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	"k8s.io/klog/v2"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/context"
+	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam"
 	ipamutil "github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam/util"
 	"github.com/smartxworks/cluster-api-provider-elf-static-ip/test/fake"
 	"github.com/smartxworks/cluster-api-provider-elf-static-ip/test/helpers"
@@ -110,4 +114,20 @@ func newCtrlContexts(objs ...client.Object) *capecontext.ControllerContext {
 func setMetal3IPForClaim(ipClaim *ipamv1.IPClaim, ip *ipamv1.IPAddress) {
 	ref := ipamutil.GetObjRef(ip)
 	ipClaim.Status.Address = &ref
+}
+
+func newMachineContext(
+	ctrlContext *capecontext.ControllerContext,
+	ipamService ipam.IPAddressManager,
+	cluster *capiv1.Cluster, machine *capiv1.Machine, elfMachine *capev1.ElfMachine) *context.MachineContext {
+	return &context.MachineContext{
+		IPAMService: ipamService,
+		MachineContext: &capecontext.MachineContext{
+			ControllerContext: ctrlContext,
+			Cluster:           cluster,
+			Machine:           machine,
+			ElfMachine:        elfMachine,
+			Logger:            ctrlContext.Logger,
+		},
+	}
 }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -29,6 +29,6 @@ const (
 
 // Default IPPool.
 const (
-	DefaultIPPoolNamespace = "cape-system"
+	DefaultIPPoolNamespace = "default"
 	DefaultIPPoolKey       = "ippool.cluster.x-k8s.io/is-default"
 )


### PR DESCRIPTION
##  Issue
[CAPE 增加了网卡级别的网络配置后](https://docs.google.com/document/d/1B6kUVyRQv_MhOaU5OeAX7ek2Ig3-9qsKISwlzvkCHRc)：按照 CAPI IPAM 社区现在的规范，IPAM 需要提供两种作用域的 IPPool：

1. 一种需要指定 namespace，只能给同样命名空间的 ElfMachine 使用。
```go
type NetworkDeviceSpec struct {
	IPAddrs []string `json:"ipAddrs,omitempty"`
	AddressesFromPools []corev1.TypedLocalObjectReference `json:"addressesFromPools,omitempty"`
}

type TypedLocalObjectReference struct {
	// APIGroup is the group for the resource being referenced.
	// If APIGroup is not specified, the specified Kind must be in the core API group.
	// For any other third-party types, APIGroup is required.
	// +optional
	APIGroup *string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
	// Kind is the type of resource being referenced
	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
	// Name is the name of resource being referenced
	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
}
```

2. 另一种不需要 namespace，可以给所有的命名空间的 ElfMachine 共享使用。


当前 Metal3 只提供了 namespace 作用域的 IPPool。

目前 SKS 的集群只使用了 default 命名空间，所以这种情况下，所有的 Machine 都在 default 命名空间，所以都可以使用到 default 命名空间的 IPPool。

但 SKS E2E 每个 case 都使用了不同的 namespace，例如 sks-e2e-main-43-k8s-mhc、sks-e2e-main-43-k8s-scale-groups。这样导致 E2E 创建的 IPPool 不能被所有的 cases 的 Machine 使用。

```go
type ObjectKey struct {
	// name is unique within a namespace to reference a object resource.
	// +kubebuilder:validation:MinLength=1
	Name string `json:"name"`
	// namespace defines the space within which the object name must be unique.
	// +optional
	Namespace string `json:"namespace,omitempty"`
}
```


##  Change

选择 IPPool 的流程调整：
(1)如果设置了 ip-pool-name：
1. 如果 elfMachine 设置了 AddressesFromPool，会使用 AddressesFromPool.name 作为
cluster.x-k8s.io/ip-pool-name，对应的 elfMachine.namespace 作为 cluster.x-k8s.io/ip-pool-namespace（这部分为了支持在 Device 配置 IPPool 加的，其他的 2-3 部分逻辑是原来的）
2. 否则会从 elfMachine 对应的 ElfMachineTemplate 获取
cluster.x-k8s.io/ip-pool-namespace 和 cluster.x-k8s.io/ip-pool-name（SKS 从 KSC 取值设置）
3. 使用 ip-pool-name 和 ip-pool-namespace 获取 IPPool，能获取到直接返回，获取不到下一步
4. 查询在默认命名空间 default 中的名为 ip-pool-name 的 IPPool

(2)如果没有设置 ip-pool-name：
1. 从 elfMachine.namespace 查询带有 is-default 标签的 IPPool，如果有多个取第一个。如果没有，下一步
2. 从默认命名空间查询所有的 查询带有 is-default 标签的 IPPool，如果有多个取第一个。


默认命名空间 `cape-system` 改成 `default` 

## Test
E2E
<img width="860" alt="image" src="https://github.com/smartxworks/cluster-api-provider-elf-static-ip/assets/19967151/43706a69-e030-42cd-9bcc-1af8a9e47791">
