### PR TITLE
SKS-2393: Check if the IP from IPPool is already in use

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - run: make lint
 
-      - run: make test
+      - run: sudo -E sh -c 'make test'
 
       - uses: codecov/codecov-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
 FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
 COPY --from=builder /workspace/manager .
+RUN setcap cap_net_raw=+ep /manager
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying PSPs
 USER 65532
 ENTRYPOINT ["/manager"]

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/go-logr/logr v1.2.4
+	github.com/go-ping/ping v1.1.0
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1
@@ -86,6 +87,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.17.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogB
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/validate v0.22.1 h1:G+c2ub6q47kfX1sOBLwIQwzBVt8qmOAARyo/9Fqs9NU=
 github.com/go-openapi/validate v0.22.1/go.mod h1:rjnrwK57VJ7A8xqfpAOEKRH8yQSGUriMu5/zuPSQ1hg=
+github.com/go-ping/ping v1.1.0 h1:3MCGhVX4fyEUuhsfwPrsEdQw6xspHkv5zHsiSoDFZYw=
+github.com/go-ping/ping v1.1.0/go.mod h1:xIFjORFzTxqIV/tDVGO4eDy/bLuSyawEeojSm3GfRGk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
@@ -231,6 +233,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -581,6 +584,7 @@ golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
@@ -620,6 +624,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -647,6 +652,7 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"os"
+	"time"
+
+	"github.com/go-ping/ping"
+)
+
+func Ping(addr string) (bool, error) {
+	pinger, err := ping.NewPinger(addr)
+	if err != nil {
+		return false, err
+	}
+
+	pinger.Count = 2
+	pinger.Timeout = 50 * time.Millisecond
+	pinger.SetPrivileged(true)
+	// Blocks until finished.
+	if err := pinger.Run(); err != nil {
+		return false, err
+	}
+	if stats := pinger.Statistics(); stats.PacketsRecv >= 1 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// SkipPingIP returns true if need to skip ping related test cases.
+// ping requires root privilege on MacOS. Add an env var SKIP_PING_IP to run tests easier on MacOS.
+func SkipPingIP() bool {
+	return os.Getenv("SKIP_PING_IP") != ""
+}

--- a/pkg/util/network_test.go
+++ b/pkg/util/network_test.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestPing(t *testing.T) {
+	if SkipPingIP() {
+		return
+	}
+
+	g := NewWithT(t)
+
+	reachable, err := Ping("127.0.0.1")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(reachable).To(BeTrue())
+
+	reachable, err = Ping("10.123.1.1")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(reachable).To(BeFalse())
+}

--- a/test/fake/ipam.go
+++ b/test/fake/ipam.go
@@ -30,6 +30,7 @@ func NewMetal3IPPool() *ipamv1.IPPool {
 			Namespace: Namespace,
 			Name:      names.SimpleNameGenerator.GenerateName("ippool-"),
 		},
+		Spec: ipamv1.IPPoolSpec{},
 	}
 }
 


### PR DESCRIPTION
## Issue

如果 IPPool 中有些 IP 已经被非 ElfMachine 使用了，IP 分配到 ElfMachine 后，创建虚拟机会导致 IP 冲突，且需要花一定的时间排查。

## Change

目前从 IPPool 过滤被非 ElfMachine 使用的 IP 实现难道较大。
简单起见，从 IPPool 获取到 IP 后，先 ping 一下 IP 是否已经被使用，如果还没有被使用继续正常的创建流程。如果 IP 已经被使用，给 ElfMachine 设置 `WaitingForStaticIPAllocationReason` 和相关的错误信息。用户发现该错误后，可以处理已经被使用的 IP，之后 ElfMachine 的创建流程会继续正常进行。


workflow 运行 `make test` 报错 `listen ip4:icmp : socket: operation not permitted`，因此改成 sudo -E sh -c 'make test'，

## Test

1. 在 IPPool 中配置已经被使用的 IP
2. 使用该 IPPool 创建集群，观察到 elfMachine 会被设置 `WaitingForStaticIPAllocationReason`
3. 释放 IPPool 中已经被使用的 IP，观察到 elfMachine 的创建流程会继续正常进行