### PR TITLE
Support contextual logging

### DIFF
--- a/controllers/elfmachine_controller_test.go
+++ b/controllers/elfmachine_controller_test.go
@@ -68,9 +68,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 	})
 
 	It("should not reconcile when ElfMachine not found", func() {
-		ctrlContext := newCtrlContexts()
+		ctrlMgrCtx := fake.NewControllerManagerContext()
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).To(BeZero())
 		Expect(err).ToNot(HaveOccurred())
@@ -81,10 +81,10 @@ var _ = Describe("ElfMachineReconciler", func() {
 		ctrlutil.AddFinalizer(elfMachine, capev1.MachineFinalizer)
 		ctrlutil.AddFinalizer(elfMachine, MachineStaticIPFinalizer)
 		elfMachine.Status.FailureMessage = pointer.String("some error")
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).To(BeZero())
 		Expect(err).ToNot(HaveOccurred())
@@ -92,9 +92,9 @@ var _ = Describe("ElfMachineReconciler", func() {
 	})
 
 	It("should not reconcile when ElfMachine without Machine", func() {
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).To(BeZero())
 		Expect(err).ToNot(HaveOccurred())
@@ -103,10 +103,10 @@ var _ = Describe("ElfMachineReconciler", func() {
 
 	It("should not reconcile when ElfMachine without Machine", func() {
 		cluster.Spec.Paused = true
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).To(BeZero())
 		Expect(err).ToNot(HaveOccurred())
@@ -116,15 +116,15 @@ var _ = Describe("ElfMachineReconciler", func() {
 	It("should not reconcile without static IP network devices", func() {
 		ctrlutil.RemoveFinalizer(elfMachine, MachineStaticIPFinalizer)
 		elfMachine.Spec.Network.Devices = []capev1.NetworkDeviceSpec{}
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).To(BeZero())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logBuffer.String()).To(ContainSubstring("No static IP network device found"))
-		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+		Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeFalse())
 	})
 
@@ -136,67 +136,67 @@ var _ = Describe("ElfMachineReconciler", func() {
 			{NetworkType: capev1.NetworkTypeIPV4DHCP},
 			{NetworkType: capev1.NetworkTypeNone},
 		}
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).To(BeZero())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logBuffer.String()).To(ContainSubstring("No need to allocate static IP"))
-		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+		Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 	})
 
 	It("should set MachineStaticIPFinalizer first", func() {
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).NotTo(BeZero())
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+		Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeFalse())
 		Expect(logBuffer.String()).To(ContainSubstring("Waiting for CAPE to set MachineFinalizer on ElfMachine"))
 
 		ctrlutil.AddFinalizer(elfMachine, capev1.MachineFinalizer)
-		ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx = fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).NotTo(BeZero())
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+		Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeTrue())
 	})
 
 	It("should not reconcile when no cloned-from-name annotation", func() {
 		ctrlutil.AddFinalizer(elfMachine, MachineStaticIPFinalizer)
 		elfMachine.Annotations[capiv1.TemplateClonedFromNameAnnotation] = ""
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).To(BeZero())
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		Expect(logBuffer.String()).To(ContainSubstring("failed to get IPPool match labels"))
-		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+		Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeTrue())
 	})
 
 	It("should not reconcile when no IPPool", func() {
 		ctrlutil.AddFinalizer(elfMachine, MachineStaticIPFinalizer)
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).To(BeZero())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logBuffer.String()).To(ContainSubstring("Waiting for IPPool to be available"))
-		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+		Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeTrue())
 	})
 
@@ -204,21 +204,21 @@ var _ = Describe("ElfMachineReconciler", func() {
 		ctrlutil.AddFinalizer(elfMachine, MachineStaticIPFinalizer)
 		elfMachineTemplate.Labels[ipam.ClusterIPPoolNamespaceKey] = metal3IPPool.Namespace
 		elfMachineTemplate.Labels[ipam.ClusterIPPoolNameKey] = metal3IPPool.Name
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result.RequeueAfter).To(Equal(config.DefaultRequeue))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Waiting for IP address for %s to be available", ipamutil.GetFormattedClaimName(elfMachine.Namespace, elfMachine.Name, 0))))
 		var ipClaim ipamv1.IPClaim
-		Expect(ctrlContext.Client.Get(ctrlContext, apitypes.NamespacedName{
+		Expect(ctrlMgrCtx.Client.Get(ctx, apitypes.NamespacedName{
 			Namespace: metal3IPPool.Namespace,
 			Name:      ipamutil.GetFormattedClaimName(elfMachine.Namespace, elfMachine.Name, 0),
 		}, &ipClaim)).To(Succeed())
 		Expect(ipClaim.Spec.Pool.Name).To(Equal(metal3IPPool.Name))
-		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+		Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeTrue())
 	})
 
@@ -232,16 +232,16 @@ var _ = Describe("ElfMachineReconciler", func() {
 		}
 		elfMachineTemplate.Labels = metal3IPPool.Labels
 		metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetFormattedClaimName(elfMachine.Namespace, elfMachine.Name, 0))
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result.RequeueAfter).To(Equal(config.DefaultRequeue))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("IPClaim %s already exists, skipping creation", ipamutil.GetFormattedClaimName(elfMachine.Namespace, elfMachine.Name, 0))))
 		Expect(logBuffer.String()).To(ContainSubstring(fmt.Sprintf("Waiting for IP address for %s to be available", ipamutil.GetFormattedClaimName(elfMachine.Namespace, elfMachine.Name, 0))))
-		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+		Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeTrue())
 	})
 
@@ -254,14 +254,14 @@ var _ = Describe("ElfMachineReconciler", func() {
 		metal3IPAddress.Spec.DNSServers = append(metal3IPAddress.Spec.DNSServers, ipamv1.IPAddressStr("2.2.2.2"), ipamv1.IPAddressStr("3.3.3.3"))
 		setMetal3IPForClaim(metal3IPClaim, metal3IPAddress)
 		elfMachine.Spec.Network.Nameservers = []string{"3.3.3.3"}
-		ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
-		fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+		ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
+		fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-		reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+		reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 		result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 		Expect(result).To(BeZero())
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+		Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 		Expect(elfMachine.Spec.Network.Devices[0].IPAddrs).To(Equal([]string{string(metal3IPAddress.Spec.Address)}))
 		// DNS server is unique and DNS server priority of ElfMachine is higher than IPPool.
 		Expect(elfMachine.Spec.Network.Nameservers).To(Equal([]string{"3.3.3.3", "2.2.2.2", "1.1.1.1"}))
@@ -278,41 +278,41 @@ var _ = Describe("ElfMachineReconciler", func() {
 		It("should remove MachineStaticIPFinalizer without IPV4 devices", func() {
 			ctrlutil.AddFinalizer(elfMachine, MachineStaticIPFinalizer)
 			elfMachine.Spec.Network.Devices = []capev1.NetworkDeviceSpec{{NetworkType: capev1.NetworkTypeIPV4DHCP}}
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 			Expect(result).To(BeZero())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(logBuffer.String()).To(ContainSubstring("No static IP network device found, but MachineStaticIPFinalizer is set and remove it"))
-			Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+			Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 			Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeFalse())
 		})
 
 		It("should remove MachineStaticIPFinalizer without IPPool", func() {
 			ctrlutil.RemoveFinalizer(elfMachine, capev1.MachineFinalizer)
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 			Expect(result).To(BeZero())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(logBuffer.String()).To(ContainSubstring("IPPool is not found, so no need to release the IP"))
-			Expect(apierrors.IsNotFound(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine))).To(BeTrue())
+			Expect(apierrors.IsNotFound(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine))).To(BeTrue())
 		})
 
 		It("should not reconcile with MachineFinalizer", func() {
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate)
+			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 			Expect(result).To(BeZero())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(logBuffer.String()).To(ContainSubstring("Waiting for MachineFinalizer to be removed"))
-			Expect(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
+			Expect(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine)).To(Succeed())
 			Expect(ctrlutil.ContainsFinalizer(elfMachine, MachineStaticIPFinalizer)).To(BeTrue())
 		})
 
@@ -323,15 +323,15 @@ var _ = Describe("ElfMachineReconciler", func() {
 			metal3IPClaim, metal3IPAddress = fake.NewMetal3IPObjects(metal3IPPool, ipamutil.GetFormattedClaimName(elfMachine.Namespace, elfMachine.Name, 0))
 			setMetal3IPForClaim(metal3IPClaim, metal3IPAddress)
 			metal3IPClaim.Labels = map[string]string{ipam.IPOwnerNameKey: fmt.Sprintf("%s-%s", elfMachine.GetNamespace(), elfMachine.GetName())}
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: capiutil.ObjectKey(elfMachine)})
 			Expect(result).To(BeZero())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(apierrors.IsNotFound(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(elfMachine), elfMachine))).To(BeTrue())
-			Expect(apierrors.IsNotFound(ctrlContext.Client.Get(ctrlContext, capiutil.ObjectKey(metal3IPClaim), metal3IPClaim))).To(BeTrue())
+			Expect(apierrors.IsNotFound(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(elfMachine), elfMachine))).To(BeTrue())
+			Expect(apierrors.IsNotFound(ctrlMgrCtx.Client.Get(ctx, capiutil.ObjectKey(metal3IPClaim), metal3IPClaim))).To(BeTrue())
 		})
 	})
 
@@ -343,26 +343,26 @@ var _ = Describe("ElfMachineReconciler", func() {
 					{APIGroup: pointer.String("ipam.metal3.io"), Kind: "IPPool", Name: metal3IPPool.Name},
 				}},
 			}
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-			machineContext := newMachineContext(ctrlContext, metal3io.NewIpam(ctrlContext.Client, ctrlContext.Logger), cluster, machine, elfMachine)
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
-			ipPool, err := reconciler.getIPPool(machineContext, elfMachine.Spec.Network.Devices[0])
+			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
+			machineContext := newMachineContext(metal3io.NewIpam(ctrlMgrCtx.Client, ctrl.LoggerFrom(ctx)), cluster, machine, elfMachine)
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
+			ipPool, err := reconciler.getIPPool(ctx, machineContext, elfMachine.Spec.Network.Devices[0])
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ipPool.GetNamespace()).To(Equal(metal3IPPool.Namespace))
 			Expect(ipPool.GetName()).To(Equal(metal3IPPool.Name))
 
 			metal3IPPool.Namespace = ipam.DefaultIPPoolNamespace
-			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-			machineContext = newMachineContext(ctrlContext, metal3io.NewIpam(ctrlContext.Client, ctrlContext.Logger), cluster, machine, elfMachine)
-			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext}
-			ipPool, err = reconciler.getIPPool(machineContext, elfMachine.Spec.Network.Devices[0])
+			ctrlMgrCtx = fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
+			machineContext = newMachineContext(metal3io.NewIpam(ctrlMgrCtx.Client, ctrl.LoggerFrom(ctx)), cluster, machine, elfMachine)
+			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
+			ipPool, err = reconciler.getIPPool(ctx, machineContext, elfMachine.Spec.Network.Devices[0])
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ipPool.GetName()).To(Equal(metal3IPPool.Name))
 
 			elfMachine.Spec.Network.Devices[0].AddressesFromPools[0].Name = "notfound"
-			ipPool, err = reconciler.getIPPool(machineContext, elfMachine.Spec.Network.Devices[0])
+			ipPool, err = reconciler.getIPPool(ctx, machineContext, elfMachine.Spec.Network.Devices[0])
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ipPool).To(BeNil())
 		})
@@ -370,33 +370,33 @@ var _ = Describe("ElfMachineReconciler", func() {
 		It("should get the default ip-pool", func() {
 			metal3IPPool.Namespace = cluster.Namespace
 			metal3IPPool.Labels = map[string]string{ipam.DefaultIPPoolKey: "true"}
-			ctrlContext := newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-			machineContext := newMachineContext(ctrlContext, metal3io.NewIpam(ctrlContext.Client, ctrlContext.Logger), cluster, machine, elfMachine)
-			reconciler := &ElfMachineReconciler{ControllerContext: ctrlContext}
-			ipPool, err := reconciler.getIPPool(machineContext, elfMachine.Spec.Network.Devices[0])
+			ctrlMgrCtx := fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
+			machineContext := newMachineContext(metal3io.NewIpam(ctrlMgrCtx.Client, ctrl.LoggerFrom(ctx)), cluster, machine, elfMachine)
+			reconciler := &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
+			ipPool, err := reconciler.getIPPool(ctx, machineContext, elfMachine.Spec.Network.Devices[0])
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ipPool.GetNamespace()).To(Equal(metal3IPPool.Namespace))
 			Expect(ipPool.GetName()).To(Equal(metal3IPPool.Name))
 
 			metal3IPPool.Namespace = ipam.DefaultIPPoolNamespace
 			metal3IPPool.Labels = map[string]string{ipam.DefaultIPPoolKey: "true"}
-			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-			machineContext = newMachineContext(ctrlContext, metal3io.NewIpam(ctrlContext.Client, ctrlContext.Logger), cluster, machine, elfMachine)
-			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext}
-			ipPool, err = reconciler.getIPPool(machineContext, elfMachine.Spec.Network.Devices[0])
+			ctrlMgrCtx = fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
+			machineContext = newMachineContext(metal3io.NewIpam(ctrlMgrCtx.Client, ctrl.LoggerFrom(ctx)), cluster, machine, elfMachine)
+			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
+			ipPool, err = reconciler.getIPPool(ctx, machineContext, elfMachine.Spec.Network.Devices[0])
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ipPool.GetNamespace()).To(Equal(metal3IPPool.Namespace))
 			Expect(ipPool.GetName()).To(Equal(metal3IPPool.Name))
 
 			metal3IPPool.Namespace = "notfoud"
 			metal3IPPool.Labels = map[string]string{ipam.DefaultIPPoolKey: "true"}
-			ctrlContext = newCtrlContexts(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
-			fake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
-			machineContext = newMachineContext(ctrlContext, metal3io.NewIpam(ctrlContext.Client, ctrlContext.Logger), cluster, machine, elfMachine)
-			reconciler = &ElfMachineReconciler{ControllerContext: ctrlContext}
-			ipPool, err = reconciler.getIPPool(machineContext, elfMachine.Spec.Network.Devices[0])
+			ctrlMgrCtx = fake.NewControllerManagerContext(elfCluster, cluster, elfMachine, machine, elfMachineTemplate, metal3IPPool, metal3IPClaim, metal3IPAddress)
+			fake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
+			machineContext = newMachineContext(metal3io.NewIpam(ctrlMgrCtx.Client, ctrl.LoggerFrom(ctx)), cluster, machine, elfMachine)
+			reconciler = &ElfMachineReconciler{ControllerManagerContext: ctrlMgrCtx}
+			ipPool, err = reconciler.getIPPool(ctx, machineContext, elfMachine.Spec.Network.Devices[0])
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ipPool).To(BeNil())
 		})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,14 +29,12 @@ import (
 	capecontext "github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	"k8s.io/klog/v2"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/context"
 	"github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam"
 	ipamutil "github.com/smartxworks/cluster-api-provider-elf-static-ip/pkg/ipam/util"
-	"github.com/smartxworks/cluster-api-provider-elf-static-ip/test/fake"
 	"github.com/smartxworks/cluster-api-provider-elf-static-ip/test/helpers"
 )
 
@@ -47,6 +45,7 @@ func TestControllers(t *testing.T) {
 
 var (
 	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
 )
 
 func TestMain(m *testing.M) {
@@ -74,20 +73,20 @@ func setup() {
 		_ = fmt.Errorf("Error setting alsologtostderr flag")
 	}
 
-	testEnv = helpers.NewTestEnvironment()
+	testEnv = helpers.NewTestEnvironment(ctx)
 
 	// Set kubeconfig.
 	os.Setenv("KUBECONFIG", testEnv.Kubeconfig)
 
 	controllerOpts := controller.Options{MaxConcurrentReconciles: 10}
 
-	if err := AddMachineControllerToManager(testEnv.GetContext(), testEnv.Manager, controllerOpts); err != nil {
+	if err := AddMachineControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, controllerOpts); err != nil {
 		panic(fmt.Sprintf("unable to setup ElfMachine controller: %v", err))
 	}
 
 	go func() {
 		fmt.Println("Starting the manager")
-		if err := testEnv.StartManager(testEnv.GetContext()); err != nil {
+		if err := testEnv.StartManager(ctx); err != nil {
 			panic(fmt.Sprintf("failed to start the envtest manager: %v", err))
 		}
 	}()
@@ -101,33 +100,20 @@ func teardown() {
 	}
 }
 
-func newCtrlContexts(objs ...client.Object) *capecontext.ControllerContext {
-	ctrlMgrContext := fake.NewControllerManagerContext(objs...)
-	ctrlContext := &capecontext.ControllerContext{
-		ControllerManagerContext: ctrlMgrContext,
-		Logger:                   ctrllog.Log,
-	}
-
-	return ctrlContext
-}
-
 func setMetal3IPForClaim(ipClaim *ipamv1.IPClaim, ip *ipamv1.IPAddress) {
 	ref := ipamutil.GetObjRef(ip)
 	ipClaim.Status.Address = &ref
 }
 
 func newMachineContext(
-	ctrlContext *capecontext.ControllerContext,
 	ipamService ipam.IPAddressManager,
 	cluster *capiv1.Cluster, machine *capiv1.Machine, elfMachine *capev1.ElfMachine) *context.MachineContext {
 	return &context.MachineContext{
 		IPAMService: ipamService,
 		MachineContext: &capecontext.MachineContext{
-			ControllerContext: ctrlContext,
-			Cluster:           cluster,
-			Machine:           machine,
-			ElfMachine:        elfMachine,
-			Logger:            ctrlContext.Logger,
+			Cluster:    cluster,
+			Machine:    machine,
+			ElfMachine: elfMachine,
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.13.1
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1
-	github.com/smartxworks/cluster-api-provider-elf v1.3.3-rc.0
+	github.com/smartxworks/cluster-api-provider-elf v1.3.3-rc.0.0.20240412070309-2f0e706ff1ee
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/mod v0.13.0
 	k8s.io/apiextensions-apiserver v0.28.4
@@ -27,6 +27,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
@@ -78,6 +79,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,8 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/openlyinc/pointy v1.2.0/go.mod h1:JodZOTJoBNaAQHeU0F/SwA4PL0lg4pKF7fYFpX291P0=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -348,6 +350,10 @@ github.com/smartxworks/cloudtower-go-sdk/v2 v2.13.1-0.20231116110941-d411454388a
 github.com/smartxworks/cloudtower-go-sdk/v2 v2.13.1-0.20231116110941-d411454388af/go.mod h1:X6R9+L438SMnLJXykSCV3fJ+AZul0hlyjITsZgrSRtM=
 github.com/smartxworks/cluster-api-provider-elf v1.3.3-rc.0 h1:+1JTJ3q677eO7Bl3nEHWrbHhBh7yG1G5Kz1z+bJKrDI=
 github.com/smartxworks/cluster-api-provider-elf v1.3.3-rc.0/go.mod h1:AvzRbdE+tP4R5E3dx5yxoIxIiYeOOowjQ+sKw6ETyVM=
+github.com/smartxworks/cluster-api-provider-elf v1.3.3-rc.0.0.20240412070309-2f0e706ff1ee h1:aUjheAw1Z24PruYrE+UxLkElvw4zT1ZyUBjsOiFgAZ0=
+github.com/smartxworks/cluster-api-provider-elf v1.3.3-rc.0.0.20240412070309-2f0e706ff1ee/go.mod h1:AvzRbdE+tP4R5E3dx5yxoIxIiYeOOowjQ+sKw6ETyVM=
+github.com/smartxworks/cluster-api-provider-elf v1.4.0-beta.0 h1:aSVakeKqVzEOzSwn86J7hUVJibpnfSDq9IQdsqrfHn8=
+github.com/smartxworks/cluster-api-provider-elf v1.4.0-beta.0/go.mod h1:7IFFlC0lBnaDS1t8RQp4SXzJ0PzPRsS403/WyPm4KK8=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=

--- a/test/fake/capi.go
+++ b/test/fake/capi.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fake
 
 import (
+	goctx "context"
+
 	capev1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	"github.com/smartxworks/cluster-api-provider-elf/pkg/context"
 	capefake "github.com/smartxworks/cluster-api-provider-elf/test/fake"
@@ -45,8 +47,8 @@ func NewClusterAndMachineObjects() (*capev1.ElfCluster, *capiv1.Cluster, *capev1
 }
 
 func InitOwnerReferences(
-	ctrlContext *context.ControllerContext,
+	ctx goctx.Context, ctrlMgrCtx *context.ControllerManagerContext,
 	elfCluster *capev1.ElfCluster, cluster *capiv1.Cluster,
 	elfMachine *capev1.ElfMachine, machine *capiv1.Machine) {
-	capefake.InitOwnerReferences(ctrlContext, elfCluster, cluster, elfMachine, machine)
+	capefake.InitOwnerReferences(ctx, ctrlMgrCtx, elfCluster, cluster, elfMachine, machine)
 }

--- a/test/fake/controller_manager_context.go
+++ b/test/fake/controller_manager_context.go
@@ -17,8 +17,6 @@ limitations under the License.
 package fake
 
 import (
-	goctx "context"
-
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	capev1 "github.com/smartxworks/cluster-api-provider-elf/api/v1beta1"
 	capecontext "github.com/smartxworks/cluster-api-provider-elf/pkg/context"
@@ -33,7 +31,6 @@ import (
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // NewControllerManagerContext returns a fake ControllerManagerContext for unit
@@ -56,9 +53,7 @@ func NewControllerManagerContext(initObjects ...client.Object) *capecontext.Cont
 	).WithObjects(initObjects...).Build()
 
 	return &capecontext.ControllerManagerContext{
-		Context:                 goctx.Background(),
 		Client:                  clientWithObjects,
-		Logger:                  ctrllog.Log.WithName(capefake.ControllerManagerName),
 		Scheme:                  scheme,
 		Name:                    capefake.ControllerManagerName,
 		LeaderElectionNamespace: capefake.LeaderElectionNamespace,

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -118,7 +118,7 @@ type (
 )
 
 // NewTestEnvironment creates a new environment spinning up a local api-server.
-func NewTestEnvironment() *TestEnvironment {
+func NewTestEnvironment(ctx goctx.Context) *TestEnvironment {
 	// Create the test environment.
 	env := &envtest.Environment{
 		ErrorIfCRDPathMissing: true,
@@ -157,11 +157,11 @@ func NewTestEnvironment() *TestEnvironment {
 		},
 		KubeConfig: env.Config,
 	}
-	managerOpts.AddToManager = func(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+	managerOpts.AddToManager = func(ctx goctx.Context, ctrlMgrCtx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {
 		return nil
 	}
 
-	mgr, err := manager.New(managerOpts)
+	mgr, err := manager.New(ctx, managerOpts)
 	if err != nil {
 		klog.Fatalf("failed to create the SKS controller manager: %v", err)
 	}


### PR DESCRIPTION
## Issue
当前 CAPE 的 context 使用不规范，例如：
* 控制器 reconcile 的 ctx 没有被使用，没有沿着调用链传播
* 日志没有使用 context：https://cluster-api.sigs.k8s.io/developer/logging

## Change
* 日志使用 CAPI 社区推荐的日志规范
* controller 传递 controller-runtime 传递过来的 ctx，并取消原有的自定义 Context，不再继承原生的 Context

## Test
E2E