### PR TITLE
SKS-3173: Fix ServiceAccount

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,6 +50,7 @@ spec:
           httpGet:
             path: /healthz
             port: healthz
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
 #! - service_account.yaml
 - role.yaml
 - role_binding.yaml
+- service_account.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system


### PR DESCRIPTION
ticket
-
[\[SKS-3173\] \[CAPE\] cape-controller 和 cape-ip-controller 混用了 RBAC 权限 - Jira](http://jira.smartx.com/browse/SKS-3173)
config/rbac/service_account.yaml 存在，但 kustomization.yaml 没有引用，导致最终没有生成 sa。
leader_election_role_binding.yaml 实际关联的是个不存在的 sa
<img width="697" alt="image" src="https://github.com/user-attachments/assets/621655de-694a-463e-907f-fd018235c035">
role_binding.yaml 和 cape-ip-controller 关联的是 default sa 。
此前没有问题是因为 cape-controller 给 default 绑定了 leader-election-role 。
当 cape-controller 不使用 default sa 后，cape-ip-controller 必须正确设置自己的 RBAC。

changed
-
修复 serviceAccount

test
-
生成的 manifests:
<img width="329" alt="image" src="https://github.com/user-attachments/assets/30bc8ae8-44bc-4c79-8f2a-361d6960ef15">
<img width="424" alt="image" src="https://github.com/user-attachments/assets/97a56cd3-51d6-4176-9de8-2073ace425d4">
<img width="624" alt="image" src="https://github.com/user-attachments/assets/234dca76-132d-4e1d-aedf-74acc69d051f">
