### PR TITLE
SKS-3173: Add Cluster permissions  to clusterRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,14 @@ rules:
 - apiGroups:
   - cluster.x-k8s.io
   resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
   - machines
   - machines/status
   verbs:

--- a/controllers/elfmachine_controller.go
+++ b/controllers/elfmachine_controller.go
@@ -49,6 +49,7 @@ import (
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachines/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachines/finalizers,verbs=update
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=elfmachinetemplates,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=ipam.metal3.io,resources=ippools,verbs=get;list;watch;update;patch


### PR DESCRIPTION
ticket
-
[\[SKS-3173\] \[CAPE\] cape-controller 和 cape-ip-controller 混用了 RBAC 权限 - Jira](http://jira.smartx.com/browse/SKS-3173)
cape-ip 还缺少 Cluster 的权限：
```
W1114 23:46:53.156341       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: failed to list *v1beta1.Cluster: clusters.cluster.x-k8s.io is forbidden: User "system:serviceaccount:cape-system:cape-ip-controller-manager" cannot list resource "clusters" in API group "cluster.x-k8s.io" at the cluster scope
E1114 23:46:53.156417       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: Failed to watch *v1beta1.Cluster: failed to list *v1beta1.Cluster: clusters.cluster.x-k8s.io is forbidden: User "system:serviceaccount:cape-system:cape-ip-controller-manager" cannot list resource "clusters" in API group "cluster.x-k8s.io" at the cluster scope
```

changed
-
添加 Cluster 的获取权限

test
-
创建使用静态 IP 的虚拟机集群成功